### PR TITLE
update gtag for new domain

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-WSJGNX16TL"></script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-C2ELSYY9VC"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}

--- a/public/index.html
+++ b/public/index.html
@@ -9,7 +9,7 @@
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
 
-    gtag('config', 'G-WSJGNX16TL');
+    gtag('config', 'G-C2ELSYY9VC');
   </script>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">


### PR DESCRIPTION
Having our domain name be projects.cosmicds.cfa.harvard.edu instead of cosmicds.github.io requires a new analytics tag. We will have to update the headers on all our resources.